### PR TITLE
Validate that RPC_URL looks like an HTTP URL

### DIFF
--- a/focus_slider_cli.js
+++ b/focus_slider_cli.js
@@ -24,6 +24,12 @@ async function main() {
     process.exit(1);
   }
 
+  if (!RPC_URL.startsWith("http")) {
+    console.error("ERROR: RPC_URL does not look like a valid HTTP(s) URL.");
+    process.exit(1);
+  }
+
+
   const provider = new ethers.JsonRpcProvider(RPC_URL);
   const contract = (() => {
     if (cmd === "get") {


### PR DESCRIPTION
Helps catch stupid mistakes like RPC_URL=123 or forgetting https://.