### PR TITLE
Warn if RPC_URL still has a common placeholder

### DIFF
--- a/focus_slider_cli.js
+++ b/focus_slider_cli.js
@@ -23,6 +23,11 @@ async function main() {
     );
     process.exit(1);
   }
+  if (RPC_URL.includes("your") && RPC_URL.includes("infura.io")) {
+    console.error(
+      "WARNING: RPC_URL looks like it still contains a placeholder Infura project key."
+    );
+  }
 
   const provider = new ethers.JsonRpcProvider(RPC_URL);
   const contract = (() => {


### PR DESCRIPTION
Catches stuff like https://mainnet.infura.io/v3/your_api_key.