### PR TITLE
Exit with a different code when command is unknown

### DIFF
--- a/focus_slider_cli.js
+++ b/focus_slider_cli.js
@@ -49,9 +49,17 @@ async function main() {
 
   if (cmd === "set") {
     if (arg === undefined) {
-      console.error("Usage: node focus_slider_cli.js set <value>");
-      process.exit(1);
-    }
+    console.error(
+    "Usage:\n" +
+      "  node focus_slider_cli.js get\n" +
+      "  node focus_slider_cli.js set <value>"
+  );
+  process.exit(2);
+// Exit codes:
+// 0 = success
+// 1 = configuration / environment error
+// 2 = bad CLI usage (unknown command, bad args)
+
 
     const value = BigInt(arg);
     console.log(`Setting focus to: ${value.toString()} ...`);


### PR DESCRIPTION
Right now you use 1 for both “bad env” and “bad command”. Use a different exit code for “unknown command” (say 2).