### PR TITLE
Add a newline after header for readability

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,8 +144,8 @@ def main() -> int:
         spd = max(0, min(10, spd))
 
       title = "🎚  web3_focus_slider" if not args.no_unicode else "web3_focus_slider"
-    print(title)
-    print(f"Needs -> privacy: {priv}/10, soundness: {snd}/10, UX speed: {spd}/10")
+    print(title + "\n")
+print(f"Needs -> privacy: {priv}/10, soundness: {snd}/10, UX speed: {spd}/10")
     print("")
     print("Profiles:")
     for key, style in STYLES.items():


### PR DESCRIPTION
The header prints immediately followed by text. A tiny readability boost with one \n.