### PR TITLE
Add constants for min/max focus values

### DIFF
--- a/focus_presets.py
+++ b/focus_presets.py
@@ -4,7 +4,8 @@ import json
 import sys
 from dataclasses import dataclass, asdict
 from typing import Dict
-
+MIN_FOCUS = 0
+MAX_FOCUS = 100
 
 @dataclass
 class FocusPreset:


### PR DESCRIPTION
Avoid “magic numbers” in the code (0–100).