### PR TITLE
Use SystemExit(main()) pattern

### DIFF
--- a/focus_presets.py
+++ b/focus_presets.py
@@ -105,4 +105,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
Makes it easier to test main() later if you change it to return exit codes.