### PR TITLE
Use raise SystemExit(main()) pattern

### DIFF
--- a/env_check.py
+++ b/env_check.py
@@ -58,4 +58,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())
+


### PR DESCRIPTION
Common pattern; easier to test main if it returns codes later.