### PR TITLE
Sort presets by value in list output for deterministic ordering

### DIFF
--- a/focus_presets.py
+++ b/focus_presets.py
@@ -78,14 +78,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def cmd_list(as_json: bool) -> None:
+    presets_sorted = sorted(PRESETS.values(), key=lambda p: p.value)
+
     if as_json:
-        data = [asdict(p) for p in PRESETS.values()]
+        data = [asdict(p) for p in presets_sorted]
         json.dump(data, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")
         return
 
-    print("Available focus presets:")
-    for p in PRESETS.values():
+    print("Available focus presets (sorted by focus value):")
+    for p in presets_sorted:
         print(f" - {p.name:8} ({p.value:3}): {p.label}")
         print(f"     {p.description}")
 


### PR DESCRIPTION
## Summary

Right now, `focus_presets.py list` prints presets in the dictionary insertion order. While this is usually stable, it's not obvious to the user and might change if the code is refactored. Sorting the output makes the CLI easier to scan and more predictable.

This PR changes the `list` command to:

- Sort presets by their `value` (focus) in ascending order.
- Use the same sorted order in both human-readable and JSON output.

## Changes

- Update `cmd_list()` to iterate over `sorted(PRESETS.values(), key=lambda p: p.value)` instead of raw `PRESETS.values()`.

## Rationale

- Deterministic ordering is friendlier for users reading the CLI output.
- Makes it easier to visually compare how “chill”, “balanced”, and “max” relate by focus value.
- No change to the CLI interface or semantics besides the ordering.